### PR TITLE
Shell.fetch to follow http redirects

### DIFF
--- a/project-spec.groovy
+++ b/project-spec.groovy
@@ -44,7 +44,7 @@ spec.scm = 'git'
  * External dependencies
  */
 spec.external = [
-  ant: 'org.apache.ant:ant:1.8.2',
+  ant: 'org.apache.ant:ant:1.9.3',
   groovy: "org.codehaus.groovy:groovy-all:${spec.versions.groovy}",
   json: 'org.json:json:20090211',
   jacksoncore: "com.fasterxml.jackson.core:jackson-core:${spec.versions.jackson}",


### PR DESCRIPTION
When fetching an artifact from nexus, nexus first returns a redirect to
another url.  This change upgrades to the latest version of ant Get
taskdef which will follow redirects.

See also https://issues.apache.org/bugzilla/show_bug.cgi?id=47433
